### PR TITLE
Feature/delegate investor package

### DIFF
--- a/implementations/diamond/contracts/register/delegateInvestors/DelegateInvestorManagement.sol
+++ b/implementations/diamond/contracts/register/delegateInvestors/DelegateInvestorManagement.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// FeverTokens Contracts v1.0.0
+
+pragma solidity ^0.8.20;
+
+import { IDelegateInvestorManagement } from "./IDelegateInvestorManagement.sol";
+import { DelegateInvestorManagementInternal } from "./DelegateInvestorManagementInternal.sol";
+
+contract DelegateInvestorManagement is IDelegateInvestorManagement, DelegateInvestorManagementInternal {
+    /**
+     * @inheritdoc IDelegateInvestorManagement
+     */
+    function setCustodianDelegate(
+        address delegate
+    ) public {
+        _setCustodianDelegate(delegate);
+    };
+
+    /**
+     * @inheritdoc IDelegateInvestorManagement
+     */
+    function unsetCustodianDelegate() public {
+        _unsetCustodianDelegate();
+    }
+
+    /**
+     * @inheritdoc IDelegateInvestorManagement
+     */
+    function isCustodianDelegate(address custodian, address delegate) public view returns (bool) {
+        return _isCustodianDelegate(custodian, delegate);
+    }
+
+    /**
+     * @inheritdoc IDelegateInvestorManagement
+     */
+    function getCustodianDelegate(address custodian) public view returns (address memory) {
+        return _getCustodianDelegate(custodian);
+    }
+
+    /**
+     * @inheritdoc IDelegateInvestorManagement
+     */
+    function delegateEnableInvestorToWhitelist(address investor_, address delegator) public {
+        _delegateEnableInvestorToWhitelist(investor_);
+    }
+
+    /**
+     * @inheritdoc IDelegateInvestorManagement
+     */
+    function delegateDisableInvestorFromWhitelist(address investor_, address delegator) public {
+        _delegateDisableInvestorFromWhitelist(investor_);
+    }
+}

--- a/implementations/diamond/contracts/register/delegateInvestors/DelegateInvestorManagementInternal.sol
+++ b/implementations/diamond/contracts/register/delegateInvestors/DelegateInvestorManagementInternal.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// FeverTokens Contracts v1.0.0
+
+pragma solidity ^0.8.20;
+
+import { InvestorManagementStorage } from "./InvestorManagementStorage.sol";
+import { InvestorManagementInternal } from "../investors/InvestorManagementInternal.sol";
+import { DelegateInvestorManagementStorage } from "./DelegateInvestorManagementStorage.sol";
+import { IDelegateInvestorManagementInternal } from "./IDelegateInvestorManagementInternal.sol";
+
+contract DelegateInvestorManagementInternal is
+    IDelegateInvestorManagementInternal,
+    InvestorManagementInternal,
+{
+    function _setCustodianDelegate(
+        address delegate
+    ) internal {
+        require(_hasRole(CST_ROLE, _msgSender()), "Caller must be CST");
+        DelegateInvestorManagementStorage.Layout storage l = DelegateInvestorManagementStorage
+            .layout();
+        address oldDelegate = l.custodianDelegates[_msgSender()];
+        l.custodianDelegates[_msgSender()] = delegate;
+        if (oldDelegate != address(0)) {
+            emit CustodianDelegateUnset(_msgSender(), oldDelegate);
+        }
+        emit CustodianDelegateSet(_msgSender(), delegate);
+    };
+
+    function _unsetCustodianDelegate() internal {
+        require(_hasRole(CST_ROLE, _msgSender()), "Caller must be CST");
+        DelegateInvestorManagementStorage.Layout storage l = DelegateInvestorManagementStorage
+            .layout();
+        address oldDelegate = l.custodianDelegates[_msgSender()];
+        l.custodianDelegates[_msgSender()] = address(0);
+        emit CustodianDelegateUnset(_msgSender(), oldDelegate);
+    }
+
+    function _isCustodianDelegate(address custodian, address delegate) internal view returns (bool) {
+        if (!_hasRole(CST_ROLE, custodian)) {
+            return false;
+        }
+        DelegateInvestorManagementStorage.Layout storage l = DelegateInvestorManagementStorage
+            .layout();
+        return l.custodianDelegates[custodian] == delegate;
+    }
+
+    function _getCustodianDelegate(address custodian) internal view returns (address memory) {
+        DelegateInvestorManagementStorage.Layout storage l = DelegateInvestorManagementStorage
+            .layout();
+        return l.custodianDelegates[custodian];
+    }
+
+    function _delegateEnableInvestorToWhitelist(address investor_, address delegator) internal {
+        require(investor_ != address(0), "investor address cannot be zero");
+        InvestorManagementStorage.Layout storage l = InvestorManagementStorage
+            .layout();
+
+        require(_isCustodianDelegate(delegator, _msgSender()), "Caller must be a custodian delegate");
+
+        _enableInvestor(investor_, delegator);
+    }
+
+    function _delegateDisableInvestorFromWhitelist(address investor_) internal {
+        require(investor_ != address(0), "investor address cannot be zero");
+        InvestorManagementStorage.Layout storage l = InvestorManagementStorage
+            .layout();
+        
+        require(_isCustodianDelegate(delegator, _msgSender()), "Caller must be a custodian delegate");
+        require(
+            l.investorInfos[investor_].custodian == delegator,
+            "only the custodian can disallow the investor"
+        );
+        l.investorInfos[investor_].allowed = false;
+
+        emit DisableInvestor(investor_);
+    }
+}

--- a/implementations/diamond/contracts/register/delegateInvestors/DelegateInvestorManagementStorage.sol
+++ b/implementations/diamond/contracts/register/delegateInvestors/DelegateInvestorManagementStorage.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// FeverTokens Contracts v1.0.0
+
+pragma solidity ^0.8.20;
+
+library DelegateInvestorManagementStorage {
+    struct Layout {
+        mapping(address => address) private custodianDelegates; /// @dev Mapping of custodians to their delegates
+    }
+
+    bytes32 internal constant STORAGE_SLOT =
+        keccak256("sobond.contracts.storage.DelegateInvestorManagement");
+
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}

--- a/implementations/diamond/contracts/register/delegateInvestors/IDelegateInvestorManagement.sol
+++ b/implementations/diamond/contracts/register/delegateInvestors/IDelegateInvestorManagement.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// FeverTokens Contracts v1.0.0
+
+pragma solidity ^0.8.20;
+
+import { IDelegateInvestorManagementInternal } from "./IDelegateInvestorManagementInternal.sol";
+
+interface IDelegateInvestorManagement is IDelegateInvestorManagementInternal {
+    /**
+     * @notice Set the delegate for a custodian. The target custodian is the msg sender.
+     * @param delegate The delegate address to set
+     */
+    function setCustodianDelegate(
+        address delegate
+    ) external;
+    
+    /**
+     * @notice Unset the delegate for a custodian. The target custodian is the msg sender.
+     * @param delegate The delegate address to unset
+     */
+    function unsetCustodianDelegate(
+        address delegate
+    ) external;
+
+    /**
+     * @notice Check if the custodian has delegated part of their role to the delegate address.
+     * @param custodian The custodian address
+     * @param delegate The delegate address
+     * @return True if the custodian address has the CST role and has delegated part of their role to the delegate address.
+     */
+    function isCustodianDelegate(address custodian, address delegate) external view returns (bool);
+
+    /**
+     * @notice Get the delegate for a custodian.
+     * @param custodian The custodian address
+     * @return The delegate address
+     */
+    function getCustodianDelegate(address custodian) external view returns (address memory);
+
+    /**
+     * @notice Enable an investor to the whitelist acting as a delegator.
+     * @param investor The investor address
+     * @param delegator The actor to enable the investor as
+     */
+    function delegateEnableInvestorToWhitelist(address investor_, address delegator) external;
+
+    /**
+     * @notice Disable an investor to the whitelist acting as a delegator.
+     * @param investor The investor address
+     * @param delegator The actor to disable the investor as
+     */
+    function delegateDisableInvestorFromWhitelist(address investor_, address delegator) external;
+}

--- a/implementations/diamond/contracts/register/delegateInvestors/IDelegateInvestorManagementInternal.sol
+++ b/implementations/diamond/contracts/register/delegateInvestors/IDelegateInvestorManagementInternal.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// FeverTokens Contracts v1.0.0
+
+pragma solidity ^0.8.20;
+
+interface IDelegateInvestorManagementInternal {
+    // Define structs, enums, events and errors used internally in the contract
+    
+    /**
+     * @notice Triggered when a delegate is added for a given custodian.
+     * @param custodian
+     * @param delegate
+     */
+    event CustodianDelegateSet(address indexed custodian, address indexed delegate);
+
+    /**
+     * @notice Triggered when a delegate is removed for a given custodian.
+     * @param custodian
+     * @param delegate
+     */
+    event CustodianDelegateUnset(address indexed custodian, address indexed delegate);
+}


### PR DESCRIPTION
New package to allow custodians to delegate their investor management powers to other addresses.

Each custodian can only have one delegated address, but the same address can be the delegate of multiple custodians.

I introduce new functions to enable/disable investors allowing to pass all the required information about the delegate and the delegator.